### PR TITLE
Add voice packet validation for OPUS decoder

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -137,6 +137,10 @@ public:
 			int16_t decodedSamples;
 			decodedSamples = opus_decode(_opusDecoder, &encodedBytes[curEncodedBytePos], payloadSize, &rawSamples[decodedRawSamples], maxRawSamples - decodedRawSamples, 0);
 
+			if (decodedSamples <= 0) {
+				return 0;
+			}
+			
 			decodedRawSamples += decodedSamples;
 			curEncodedBytePos += payloadSize;
 			encodedBytesCount -= payloadSize;

--- a/Main.cpp
+++ b/Main.cpp
@@ -788,6 +788,7 @@ void SV_ParseVoiceData_Hook(client_t *pClient) {
 
 						std::size_t decodedSampleCount = pClientData->NewCodec2->Decode((const uint8_t *)buf.PeekRead(), bytesCount, &rawSamples[rawSampleCount], remainSamples);
 						
+						// The bug is still not fixed in mainstream steamclient.dll, so we need to block any further propagation of invalid payloads
 						if (decodedSampleCount == std::size_t(-1)) {
 							LOG_MESSAGE(PLID, "Invalid voice packet from %s", pClient->m_szPlayerName);
 							EngineUTIL::DropClient(pClient, false, "Invalid voice packet");

--- a/Main.cpp
+++ b/Main.cpp
@@ -134,8 +134,7 @@ public:
 			}
 			//LOG_MESSAGE(PLID, "Normal frame");
 
-			int16_t decodedSamples;
-			decodedSamples = opus_decode(_opusDecoder, &encodedBytes[curEncodedBytePos], payloadSize, &rawSamples[decodedRawSamples], maxRawSamples - decodedRawSamples, 0);
+			int16_t decodedSamples = opus_decode(_opusDecoder, &encodedBytes[curEncodedBytePos], payloadSize, &rawSamples[decodedRawSamples], maxRawSamples - decodedRawSamples, 0);
 
 			if (decodedSamples <= 0) {
 				return 0;
@@ -785,7 +784,13 @@ void SV_ParseVoiceData_Hook(client_t *pClient) {
 							return;
 						}
 
-						rawSampleCount += pClientData->NewCodec2->Decode((const uint8_t *)buf.PeekRead(), bytesCount, &rawSamples[rawSampleCount], remainSamples);
+						int numDecodedSamples = pClientData->NewCodec2->Decode((const uint8_t *)buf.PeekRead(), bytesCount, &rawSamples[rawSampleCount], remainSamples);
+						
+						if (numDecodedSamples <= 0) {
+							return;
+						}
+						
+						rawSampleCount += numDecodedSamples;
 						buf.SkipBytes(bytesCount);
 					} else {
 						LOG_MESSAGE(PLID, "Voice packet invalid vdata size (cur = %u, need = %u) from %s", remainBytes, bytesCount, pClient->m_szPlayerName);

--- a/Main.cpp
+++ b/Main.cpp
@@ -789,8 +789,8 @@ void SV_ParseVoiceData_Hook(client_t *pClient) {
 						std::size_t decodedSampleCount = pClientData->NewCodec2->Decode((const uint8_t *)buf.PeekRead(), bytesCount, &rawSamples[rawSampleCount], remainSamples);
 						
 						if (decodedSampleCount == std::size_t(-1)) {
-							LOG_MESSAGE(PLID, "Invalid voice packet from %s", remainBytes, bytesCount, pClient->m_szPlayerName);
-							EngineUTIL::DropClient(pClient, false, "Invalid voice packet", remainBytes, bytesCount);
+							LOG_MESSAGE(PLID, "Invalid voice packet from %s", pClient->m_szPlayerName);
+							EngineUTIL::DropClient(pClient, false, "Invalid voice packet");
 
 							return;
 						}


### PR DESCRIPTION
This fixes vulnerable client-side attack via invalid voice packet.
Correction in Revoice: https://github.com/s1lentq/revoice/commit/5f71fde202bcc86dd8fd14defb0876c3484e5b38